### PR TITLE
Add Django 3.0 support, drop py3.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,13 +68,6 @@ jobs:
     environment:
       TOXFACTOR: py35
 
-  test-py34:
-    <<: *test-steps
-    docker:
-      - image: circleci/python:3.4
-    environment:
-      TOXFACTOR: py34
-
 
 workflows:
   version: 2
@@ -94,10 +87,6 @@ workflows:
             - lint
 
       - test-py35:
-          requires:
-            - lint
-
-      - test-py34:
           requires:
             - lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
+  test-py38:
+    <<: *test-steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXFACTOR: py38
+
   test-py37:
     <<: *test-steps
     docker:
@@ -75,6 +82,10 @@ workflows:
     jobs:
       - lint
       - dist:
+          requires:
+            - lint
+
+      - test-py38:
           requires:
             - lint
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 -------
 
+v3.0.3 (unreleased)
+^^^^^^^^^^^^^^^^^^^
+- Add Django 3.0 support, drop Python 3.4
+
 v3.0.2 12/21/2018
 ^^^^^^^^^^^^^^^^^
 - Add Python 3.7 & Django 2.1 support

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changes
 
 v3.0.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
-- Add Django 3.0 support, drop Python 3.4
+- Add Python 3.8 & Django 3.0 support
+- Drop Python 3.4 support
 
 v3.0.2 12/21/2018
 ^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 
 jsonfield2 aims to support all current `versions of Django`_, however the explicity tested versions are:
 
-* **Python:** 3.4, 3.5, 3.6, 3.7
+* **Python:** 3.5, 3.6, 3.7, 3.8
 * **Django:** 1.11, 2.0, 2.1, 2.2
 
 .. _versions of Django: https://www.djangoproject.com/download/#supported-versions

--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -4,7 +4,7 @@ import json
 import uuid
 
 from django.db.models.query import QuerySet
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
@@ -34,15 +34,15 @@ class JSONEncoder(json.JSONEncoder):
             representation = obj.isoformat()
             return representation
         elif isinstance(obj, datetime.timedelta):
-            return six.text_type(obj.total_seconds())
+            return str(obj.total_seconds())
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
             return float(obj)
         elif isinstance(obj, uuid.UUID):
-            return six.text_type(obj)
+            return str(obj)
         elif isinstance(obj, QuerySet):
             return tuple(obj)
-        elif isinstance(obj, six.binary_type):
+        elif isinstance(obj, bytes):
             # Best-effort for binary blobs. See #4187.
             return obj.decode('utf-8')
         elif hasattr(obj, 'tolist'):

--- a/jsonfield/forms.py
+++ b/jsonfield/forms.py
@@ -1,7 +1,6 @@
 import json
 
 from django.forms import ValidationError, fields
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -11,7 +10,7 @@ class JSONFieldMixin(object):
         super(JSONFieldMixin, self).__init__(*args, **kwargs)
 
     def to_python(self, value):
-        if isinstance(value, six.string_types) and value:
+        if isinstance(value, str) and value:
             try:
                 return json.loads(value, **self.load_kwargs)
             except ValueError:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,10 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Framework :: Django',
     ],
 )

--- a/tests/test_jsonfield.py
+++ b/tests/test_jsonfield.py
@@ -8,7 +8,6 @@ from django.core.serializers import deserialize, serialize
 from django.core.serializers.base import DeserializationError
 from django.forms import ModelForm, ValidationError
 from django.test import TestCase
-from django.utils.six import string_types
 
 from jsonfield.fields import JSONField
 
@@ -299,7 +298,7 @@ class TestFieldAPIMethods(TestCase):
         value = {'a': 1}
         prepared_value = json_field_instance.get_db_prep_value(
             value, connection=None, prepared=False)
-        self.assertIsInstance(prepared_value, string_types)
+        self.assertIsInstance(prepared_value, str)
         self.assertDictEqual(value, json.loads(prepared_value))
         self.assertIs(json_field_instance.get_db_prep_value(
             None, connection=None, prepared=True), None)
@@ -311,7 +310,7 @@ class TestFieldAPIMethods(TestCase):
         value = {'a': 1}
         prepared_value = json_field_instance.get_db_prep_value(
             value, connection=None, prepared=False)
-        self.assertIsInstance(prepared_value, string_types)
+        self.assertIsInstance(prepared_value, str)
         self.assertDictEqual(value, json.loads(prepared_value))
         self.assertIs(json_field_instance.get_db_prep_value(
             None, connection=None, prepared=True), None)
@@ -329,7 +328,7 @@ class TestFieldAPIMethods(TestCase):
         json_field_instance = JSONField(null=False)
         value = {'a': 1}
         prepared_value = json_field_instance.get_prep_value(value)
-        self.assertIsInstance(prepared_value, string_types)
+        self.assertIsInstance(prepared_value, str)
         self.assertDictEqual(value, json.loads(prepared_value))
         already_json = json.dumps(value)
         double_prepared_value = json_field_instance.get_prep_value(
@@ -342,7 +341,7 @@ class TestFieldAPIMethods(TestCase):
         json_field_instance = JSONField(null=True)
         value = {'a': 1}
         prepared_value = json_field_instance.get_prep_value(value)
-        self.assertIsInstance(prepared_value, string_types)
+        self.assertIsInstance(prepared_value, str)
         self.assertDictEqual(value, json.loads(prepared_value))
         already_json = json.dumps(value)
         double_prepared_value = json_field_instance.get_prep_value(

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{35,36}-django20,
     py{35,36,37}-django21,
     py{35,36,37}-django22,
-    py{36,37}-django30,
+    py{36,37,38}-django30,
     isort,lint,dist,warnings,
 
 [testenv]
@@ -19,7 +19,7 @@ deps =
     django20: Django~=2.0.0
     django21: Django~=2.1.0
     django22: Django~=2.2.0
-    django30: Django>=3.0a1,<3.1
+    django30: Django>=3.0b1,<3.1
 
 [testenv:isort]
 commands = isort --check-only --recursive jsonfield tests {posargs:--diff}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py{34,35,36}-django111,
-    py{34,35,36}-django20,
+    py{35,36}-django111,
+    py{35,36}-django20,
     py{35,36,37}-django21,
     py{35,36,37}-django22,
+    py{36,37}-django30,
     isort,lint,dist,warnings,
 
 [testenv]
@@ -18,6 +19,7 @@ deps =
     django20: Django~=2.0.0
     django21: Django~=2.1.0
     django22: Django~=2.2.0
+    django30: Django>=3.0a1,<3.1
 
 [testenv:isort]
 commands = isort --check-only --recursive jsonfield tests {posargs:--diff}


### PR DESCRIPTION
* Added Django3.0a to tox (note that Django master is now 3.1 dev)
* Dropped py3.4 since it was end of life in March 2019
* removed django.utils.six (fixes Django 3 compat, not needed since we don't support py2)
* Removed py2 from setup.py (since it was dropped in 3.0.0)
* Added py3.7 to setup.py