### PR TITLE
Add support for Django 1.11 LTS

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -47,7 +47,7 @@ class JSONFieldMixin(models.Field):
         except ValueError:
             raise ValidationError(_("Enter valid JSON."))
 
-    def from_db_value(self, value, expression, connection):
+    def from_db_value(self, value, expression, connection, context=None):
         if value is None:
             return None
         return json.loads(value, **self.load_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/rpkilby/jsonfield2/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
-    install_requires=['Django >= 2.2'],
+    install_requires=['Django >= 1.11'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -81,3 +81,13 @@ class TestFieldAPIMethods(TestCase):
 
         self.assertEqual(kwargs['dump_kwargs'], {'separators': (',', ':')})
         self.assertEqual(kwargs['load_kwargs'], {'object_pairs_hook': dict})
+
+    def test_from_db_value(self):
+        json_field_instance = JSONField(null=True)
+        value = '{"a": 1}'
+        # Ensure that form_db_value can be called with 5 arguments
+        # to be django 1.11 compatible
+        # https://docs.djangoproject.com/en/2.0/releases/2.0/
+        from_db_value = json_field_instance.from_db_value(
+            value, None, None, None)
+        self.assertEqual({'a': 1}, from_db_value)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     coverage
+    django111: Django>=1.11,<2.0
     django22: Django~=2.2.0
     django30: Django~=3.0.0
 


### PR DESCRIPTION
Hi @rpkilby, to facilitate migrations from django 1.11 to Django 2.2+ I stopped using jsonfield to use jsonfield2, I came across some issues since the signature of `from_db_value` has changed since Django 2.0.
https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value

Here is a little fix to support Django 1.11 until it is time to drop it later this year.